### PR TITLE
New priors (v1.0.11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,26 @@ Work related to VBMC has been presented at seminars in Oxford (UK), Bristol (UK)
 1. Acerbi, L. (2018). Variational Bayesian Monte Carlo. In *Advances in Neural Information Processing Systems 31*: 8222-8232. ([paper + supplement on arXiv](https://arxiv.org/abs/1810.05558), [NeurIPS Proceedings](https://papers.nips.cc/paper/8043-variational-bayesian-monte-carlo))
 2. Acerbi, L. (2020). Variational Bayesian Monte Carlo with Noisy Likelihoods. In *Advances in Neural Information Processing Systems 33*: 8211-8222 ([paper + supplement on arXiv](https://arxiv.org/abs/2006.08655), [NeurIPS Proceedings](https://papers.nips.cc/paper/2020/hash/5d40954183d62a82257835477ccad3d2-Abstract.html)).
 
+```
+@article{acerbi2018variational,
+  title={{V}ariational {B}ayesian {M}onte {C}arlo},
+  author={Acerbi, Luigi},
+  journal={Advances in Neural Information Processing Systems},
+  volume={31},
+  pages={8222--8232},
+  year={2018}
+}
+
+@article{acerbi2020variational,
+  title={Variational {B}ayesian {M}onte {C}arlo with noisy likelihoods},
+  author={Acerbi, Luigi},
+  journal={Advances in Neural Information Processing Systems},
+  volume={33},
+  pages={8211--8222},
+  year={2020}
+}
+```
+
 Please cite both references if you use VBMC in your work (the 2018 paper introduced the framework, and the 2020 paper includes a number of major improvements, including but not limited to support for noisy likelihoods). You can cite VBMC in your work with something along the lines of
 
 > We estimated approximate posterior distibutions and approximate lower bounds to the model evidence of our models using Variational Bayesian Monte Carlo (VBMC; Acerbi, 2018, 2020). VBMC combines variational inference and active-sampling Bayesian quadrature to perform approximate Bayesian inference in a sample-efficient manner.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Work related to VBMC has been presented at seminars in Oxford (UK), Bristol (UK)
 }
 
 @article{acerbi2020variational,
-  title={Variational {B}ayesian {M}onte {C}arlo with noisy likelihoods},
+  title={{V}ariational {B}ayesian {M}onte {C}arlo with noisy likelihoods},
   author={Acerbi, Luigi},
   journal={Advances in Neural Information Processing Systems},
   volume={33},

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Variational Bayesian Monte Carlo (VBMC) - v1.0.10
+# Variational Bayesian Monte Carlo (VBMC) - v1.0.11
 
 **News:** 
 - Added a [Presentations](#presentations) section with links to (relatively) recent slides and video recordings of VBMC related work.

--- a/misc/vbinit_vbmc.m
+++ b/misc/vbinit_vbmc.m
@@ -8,8 +8,6 @@ K = vp.K;
 
 Nstar = size(Xstar,1);
 
-add_jitter = true;
-
 % Compute moments
 %X_mean = mean(X,1);
 %X_cov = cov(X);
@@ -40,11 +38,12 @@ end
 for iOpt = 1:Nopts
     vp0_vec(iOpt) = vp;
     vp0_vec(iOpt).K = Knew;
-        
+    
     mu = mu0;
     sigma = sigma0;
     lambda = lambda0;
     if vp.optimize_weights; w = w0; end
+    add_jitter = true;
     
     switch type
         

--- a/shared/msmoothboxpdf.m
+++ b/shared/msmoothboxpdf.m
@@ -1,0 +1,63 @@
+function y = msmoothboxpdf(x,a,b,sigma)
+%MSMOOTHBOXPDF Multivariate smooth-box probability density function.
+%   Y = MSMOOTHBOXPDF(X,A,B,SIGMA) returns the pdf of the multivariate 
+%   smooth-box distribution with pivots A and B and scale SIGMA, evaluated 
+%   at the values in X. The multivariate smooth-box pdf is the product of 
+%   univariate smooth-box pdfs in each dimension. 
+%
+%   For each dimension i, the univariate smooth-box pdf is defined as a
+%   uniform distribution between pivots A(i), B(i) and Gaussian tails that
+%   fall starting from p(A(i)) to the left (resp., p(B(i)) to the right) 
+%   with standard deviation SIGMA(i).
+%                          
+%   X can be a matrix, where each row is a separate point and each column
+%   is a different dimension. Similarly, A, B, and SIGMA can also be
+%   matrices of the same size as X.
+%
+%   See also MSMOOTHBOXRND.
+
+% Luigi Acerbi 2022
+
+[N,D] = size(x);
+
+if any(sigma(:) <= 0)
+    error('msmoothboxpdf:NonPositiveSigma', ...
+        'All elements of SIGMA should be positive.');    
+end
+
+if D > 1
+    if isscalar(a); a = a*ones(1,D); end
+    if isscalar(b); b = b*ones(1,D); end
+    if isscalar(sigma); sigma = sigma*ones(1,D); end
+end
+
+if size(a,2) ~= D || size(b,2) ~= D || size(sigma,2) ~= D
+    error('msmoothboxpdf:SizeError', ...
+        'A, B, SIGMA should be scalars or have the same number of columns as X.');
+end
+
+if size(a,1) == 1; a = repmat(a,[N,1]); end
+if size(b,1) == 1; b = repmat(b,[N,1]); end
+if size(sigma,1) == 1; sigma = repmat(sigma,[N,1]); end
+
+if any(a(:) >= b(:))
+    error('msmoothboxpdf:OrderError', ...
+        'For all elements of A and B, the order A < B should hold.');
+end
+
+y = zeros(size(x));
+nf = 1 + 1/sqrt(2*pi)./sigma.*(b - a);
+
+for ii = 1:D
+    idx = x(:,ii) < a(:,ii);
+    y(idx,ii) = 1/sqrt(2*pi)./sigma(idx,ii).* exp(-0.5*((x(idx,ii) - a(idx,ii))./sigma(idx,ii)).^2) ./ nf(idx,ii);
+
+    idx = x(:,ii) >= a(:,ii) & x(:,ii) <= b(:,ii);
+    y(idx,ii) = 1/sqrt(2*pi)./sigma(idx,ii) ./ nf(idx,ii);
+    
+    idx = x(:,ii) > b(:,ii);
+    y(idx,ii) = 1/sqrt(2*pi)./sigma(idx,ii).* exp(-0.5*((x(idx,ii) - b(idx,ii))./sigma(idx,ii)).^2) ./ nf(idx,ii);
+ 
+end
+
+y = prod(y,2);

--- a/shared/msmoothboxrnd.m
+++ b/shared/msmoothboxrnd.m
@@ -1,0 +1,74 @@
+function r = msmoothboxrnd(a,b,sigma,n)
+%MSMOOTHBOXRND Random arrays from the multivariate smooth-box distribution.
+%   R = MSMOOTHBOXRND(A,B,SIGMA) returns an N-by-D matrix R of random 
+%   vectors chosen from the multivariate smooth-box distribution 
+%   with pivots A and B and scale SIGMA. A, B and SIGMA are N-by-D matrices, 
+%   and MSMOOTHBOXRND generates each row of R using the corresponding row 
+%   of A, B and SIGMA.
+%
+%   R = MSMOOTHBOXRND(A,B,SIGMA,N) returns a N-by-D matrix R of random 
+%   vectors chosen from the multivariate smooth-box distribution 
+%   with pivots A and B and scale SIGMA.
+%
+%   See also MSMOOTHBOXPDF.
+
+% Luigi Acerbi 2022
+
+[Na,Da] = size(a);
+[Nb,Db] = size(b);
+[Nsigma,Dsigma] = size(sigma);
+
+if any(sigma(:) <= 0)
+    error('msmoothboxrnd:NonPositiveSigma', ...
+        'All elements of SIGMA should be positive.');    
+end
+
+if nargin < 4 || isempty(n)
+    n = max([Na,Nb,Nsigma]);
+else
+    if (Na ~= 1 && Na ~= n) || (Nb ~= 1 && Nb ~= n) || ...
+            (Nsigma ~= 1 && Nsigma ~= n)
+        error('msmoothboxrnd:SizeError', ...
+            'A, B, SIGMA should be 1-by-D or N-by-D arrays.');
+    end    
+end
+if Na ~= Nb || Da ~= Db || Na ~= Nsigma || Da ~= Dsigma
+    error('msmoothboxrnd:SizeError', ...
+        'A, B, SIGMA should be arrays of the same size.');
+end
+
+D = Da;
+
+if size(a,1) == 1; a = repmat(a,[n,1]); end
+if size(b,1) == 1; b = repmat(b,[n,1]); end
+if size(sigma,1) == 1; sigma = repmat(sigma,[n,1]); end
+
+r = zeros(n,D);
+
+nf = 1 + 1/sqrt(2*pi)./sigma.*(b - a);
+
+% Sample one dimension at a time
+for d = 1:D    
+    % Draw component (left/right tails or plateau)
+    u = nf(:,d) .* rand(n,1);
+    
+    % Left Gaussian tails
+    idx = u < 0.5;
+    if any(idx)
+        z1 = abs(randn(sum(idx),1).*sigma(idx,d));    
+        r(idx,d) = a(idx) - z1;
+    end
+    
+    % Right Gaussian tails
+    idx = (u >= 0.5 & u < 1);
+    if any(idx)
+        z1 = abs(randn(sum(idx),1).*sigma(idx,d));
+        r(idx,d) = b(idx) + z1;
+    end
+    
+    % Plateau
+    idx = u >= 1;
+    if any(idx)
+        r(idx,d) = a(idx,d) + (b(idx,d) - a(idx,d)).*rand(sum(idx),1);
+    end
+end

--- a/shared/msplinetrapezpdf.m
+++ b/shared/msplinetrapezpdf.m
@@ -1,25 +1,66 @@
 function y = msplinetrapezpdf(x,a,b,c,d)
-%MSPLINETRAPEZPDF Multivariate cubic-spline trapezoidal probability density function.
+%MSPLINETRAPEZPDF Multivariate spline-trapezoidal probability density fcn (pdf).
+%   Y = MSPLINETRAPEZPDF(X,A,B,C,D) returns the pdf of the multivariate 
+%   spline-trapezoidal distribution with external bounds A and D and internal 
+%   points B and C, evaluated at the values in X. The multivariate pdf is 
+%   the product of univariate spline-trapezoidal pdfs in each dimension. 
+%
+%   For each dimension i, the univariate spline-trapezoidal pdf is defined 
+%   as a trapezoidal pdf whose points A, B and C, D are connected by cubic
+%   splines such that the pdf is continuous and its derivatives at A, B, C,
+%   and D are zero (so the derivatives are also continuous):
+%
+%                 |       __________
+%                 |      /|        |\
+%         p(X(i)) |     / |        | \ 
+%                 |    /  |        |  \
+%                 |___/___|________|___\____
+%                    A(i) B(i)     C(i) D(i)
+%                             X(i)
+%                          
+%   X can be a matrix, where each row is a separate point and each column
+%   is a different dimension. Similarly, A, B, C, and D can also be
+%   matrices of the same size as X.
+%
+%   See also MSPLINETRAPEZRND.
 
-% a < b < c < d
+% Luigi Acerbi 2022
+
+[N,D] = size(x);
+
+if D > 1
+    if isscalar(a); a = a*ones(1,D); end
+    if isscalar(b); b = b*ones(1,D); end
+    if isscalar(c); c = c*ones(1,D); end
+    if isscalar(d); d = d*ones(1,D); end
+end
+
+if size(a,2) ~= D || size(b,2) ~= D || size(c,2) ~= D || size(d,2) ~= D
+    error('msplinetrapezpdf:SizeError', ...
+        'A, B, C, D should be scalars or have the same number of columns as X.');
+end
+
+if size(a,1) == 1; a = repmat(a,[N,1]); end
+if size(b,1) == 1; b = repmat(b,[N,1]); end
+if size(c,1) == 1; c = repmat(c,[N,1]); end
+if size(d,1) == 1; d = repmat(d,[N,1]); end
 
 y = zeros(size(x));
 % Normalization factor
 % nf = c - b + 0.5*(d - c + b - a);
 nf = 0.5*(c - b + d - a);
 
-for ii = 1:size(x,2)
+for ii = 1:D    
+    idx = x(:,ii) >= a(:,ii) & x(:,ii) < b(:,ii);
+    z = (x(idx,ii) - a(idx,ii))./(b(idx,ii) - a(idx,ii));    
+    y(idx,ii) = (-2*z.^3 + 3*z.^2) ./ nf(idx,ii);
     
-    idx = x(:,ii) >= a(ii) & x(:,ii) < b(ii);
-    z = (x(idx,ii) - a(ii))/(b(ii) - a(ii));    
-    y(idx,ii) = (-2*z.^3 + 3*z.^2) / nf(ii);
+    idx = x(:,ii) >= b(:,ii) & x(:,ii) < c(:,ii);
+    y(idx,ii) = 1 ./ nf(idx,ii);
     
-    idx = x(:,ii) >= b(ii) & x(:,ii) < c(ii);
-    y(idx,ii) = 1 / nf(ii);
-    
-    idx = x(:,ii) >= c(ii) & x(:,ii) < d(ii);
-    z = 1 - (x(idx,ii) - c(ii))/(d(ii) - c(ii));    
-    y(idx,ii) = (-2*z.^3 + 3*z.^2) / nf(ii);
+    idx = x(:,ii) >= c(:,ii) & x(:,ii) < d(:,ii);
+    z = 1 - (x(idx,ii) - c(idx,ii)) ./ (d(idx,ii) - c(idx,ii));    
+    y(idx,ii) = (-2*z.^3 + 3*z.^2) ./ nf(idx,ii);
 end
 
 y = prod(y,2);

--- a/shared/msplinetrapezrnd.m
+++ b/shared/msplinetrapezrnd.m
@@ -1,0 +1,73 @@
+function r = msplinetrapezrnd(a,u,v,b,n)
+%MSPLINETRAPEZRND Random arrays from the multivariate spline-trapezoidal distribution.
+%   R = MSPLINETRAPEZRND(A,U,V,B) returns an N-by-D matrix R of random 
+%   vectors chosen from the multivariate spline-trapezoidal distribution 
+%   with external bounds A and B and internal points U and V. A, U, V and B 
+%   are N-by-D matrices, and MSPLINETRAPEZRND generates each row of R using 
+%   the corresponding row of A, U, V and B.
+%
+%   R = MSPLINETRAPEZRND(A,U,V,B,N) returns a N-by-D matrix R of random 
+%   vectors chosen from the multivariate spline-trapezoidal distribution 
+%   with external bounds A and B and internal points U and V.
+%
+%   See also MSPLINETRAPEZPDF.
+
+% Luigi Acerbi 2022
+
+[Na,Da] = size(a);
+[Nu,Du] = size(u);
+[Nv,Dv] = size(v);
+[Nb,Db] = size(b);
+
+if nargin < 3 || isempty(n)
+    n = max([Na,Nu,Nv,Nb]);
+else
+    if (Na ~= 1 && Na ~= n) || (Nb ~= 1 && Nb ~= n) || ...
+            (Nu ~= 1 && Nu ~= n) || (Nv ~= 1 && Nv ~= n)
+        error('msplinetrapezrnd:SizeError', ...
+            'A, U, V, B should be 1-by-D or N-by-D arrays.');
+    end    
+end
+if Na ~= Nb || Da ~= Db || Na ~= Nu || Da ~= Du || Na ~= Nv || Da ~= Dv
+    error('msplinetrapezrnd:SizeError', ...
+        'A, U, V, B should be arrays of the same size.');
+end
+
+D = Da;
+
+if size(a,1) == 1; a = repmat(a,[n,1]); end
+if size(u,1) == 1; u = repmat(u,[n,1]); end
+if size(v,1) == 1; v = repmat(v,[n,1]); end
+if size(b,1) == 1; b = repmat(b,[n,1]); end
+
+r = zeros(n,D);
+
+% Sample one dimension at a time
+for d = 1:D
+    % Compute maximum of one-dimensional pdf
+    x0 = 0.5*(u(:,d) + v(:,d));
+    y_max = msplinetrapezpdf(x0,a(:,d),u(:,d),v(:,d),b(:,d));
+    
+    idx = true(n,1);
+    r1 = zeros(n,1);
+    n1 = sum(idx);
+    
+    % Keep doing rejection sampling
+    while n1 > 0        
+        % Uniform sampling in the box
+        r1(idx) = bsxfun(@plus, a(idx,d), bsxfun(@times, rand(n1,1), b(idx,d) - a(idx,d)));
+        
+        % Rejection sampling
+        z1 = rand(n1,1) .* y_max(idx);
+        y1 = msplinetrapezpdf(r1(idx),a(idx,d),u(idx,d),v(idx,d),b(idx,d));
+        
+        idx_new = false(n,1);        
+        idx_new(idx) = z1 > y1; % Resample points outside
+        
+        idx = idx_new;
+        n1 = sum(idx);
+    end
+    
+    % Assign d-th dimension
+    r(:,d) = r1;
+end

--- a/shared/mtrapezpdf.m
+++ b/shared/mtrapezpdf.m
@@ -1,22 +1,59 @@
-function y = mtrapezpdf(x,a,b,c,d)
-%MTRAPEZPDF Multivariate trapezoidal probability density function.
+function y = mtrapezpdf(x,a,u,v,b)
+%MTRAPEZPDF Multivariate trapezoidal probability density function (pdf).
+%   Y = MTRAPEZPDF(X,A,U,V,B) returns the pdf of the multivariate trapezoidal
+%   distribution with external bounds A and B and internal points U and V,
+%   evaluated at the values in X. The multivariate trapezoidal
+%   pdf is the product of univariate trapezoidal pdfs in each dimension. 
+%
+%   For each dimension i, the univariate trapezoidal pdf is defined as:
+%
+%                 |       __________
+%                 |      /|        |\
+%         p(X(i)) |     / |        | \ 
+%                 |    /  |        |  \
+%                 |___/___|________|___\____
+%                    A(i) U(i)     V(i) B(i)
+%                             X(i)
+%                          
+%   X can be a matrix, where each row is a separate point and each column
+%   is a different dimension. Similarly, A, B, C, and D can also be
+%   matrices of the same size as X.
+%
+%   See also MTRAPEZRND.
 
-% a < b < c < d
+% Luigi Acerbi 2022
+
+[N,D] = size(x);
+
+if D > 1
+    if isscalar(a); a = a*ones(1,D); end
+    if isscalar(u); u = u*ones(1,D); end
+    if isscalar(v); v = v*ones(1,D); end
+    if isscalar(b); b = b*ones(1,D); end
+end
+
+if size(a,2) ~= D || size(u,2) ~= D || size(v,2) ~= D || size(b,2) ~= D
+    error('mtrapezpdf:SizeError', ...
+        'A, B, C, D should be scalars or have the same number of columns as X.');
+end
+
+if size(a,1) == 1; a = repmat(a,[N,1]); end
+if size(u,1) == 1; u = repmat(u,[N,1]); end
+if size(v,1) == 1; v = repmat(v,[N,1]); end
+if size(b,1) == 1; b = repmat(b,[N,1]); end
 
 y = zeros(size(x));
-nf = 0.5 * (d - a + c - b) .* (b - a);
+nf = 0.5 * (b - a + v - u) .* (u - a);
 
-for ii = 1:size(x,2)
+for ii = 1:D
+    idx = x(:,ii) >= a(:,ii) & x(:,ii) < u(:,ii);
+    y(idx,ii) = (x(idx,ii) - a(idx,ii)) ./ nf(idx,ii);
     
-    idx = x(:,ii) >= a(ii) & x(:,ii) < b(ii);
-    y(idx,ii) = (x(idx,ii) - a(ii)) / nf(ii);
+    idx = x(:,ii) >= u(:,ii) & x(:,ii) < v(:,ii);
+    y(idx,ii) = (u(idx,ii)-a(idx,ii)) ./ nf(idx,ii);
     
-    idx = x(:,ii) >= b(ii) & x(:,ii) < c(ii);
-    y(idx,ii) = (b(ii)-a(ii)) / nf(ii);
-    
-    idx = x(:,ii) >= c(ii) & x(:,ii) < d(ii);
-    y(idx,ii) = (d(ii) - x(idx,ii))/(d(ii) - c(ii)) *  (b(ii)-a(ii)) / nf(ii);    
+    idx = x(:,ii) >= v(:,ii) & x(:,ii) < b(:,ii);
+    y(idx,ii) = (b(idx,ii) - x(idx,ii))./(b(idx,ii) - v(idx,ii)) .*  (u(idx,ii)-a(idx,ii)) ./ nf(idx,ii);
 end
 
 y = prod(y,2);
-

--- a/shared/mtrapezrnd.m
+++ b/shared/mtrapezrnd.m
@@ -1,0 +1,73 @@
+function r = mtrapezrnd(a,u,v,b,n)
+%MTRAPEZRND Random arrays from the multivariate trapezoidal distribution.
+%   R = MTRAPEZRND(A,U,V,B) returns an N-by-D matrix R of random vectors
+%   chosen from the multivariate trapezoidal distribution with external 
+%   bounds A and B and internal points U and V. A, U, V and B are N-by-D 
+%   matrices, and MTRAPEZRND generates each row of R using the corresponding 
+%   row of A, U, V and B.
+%
+%   R = MTRAPEZRND(A,U,V,B,N) returns a N-by-D matrix R of random vectors
+%   chosen from the multivariate trapezoidal distribution with external 
+%   bounds A and B and internal points U and V.
+%
+%   See also MTRAPEZPDF.
+
+% Luigi Acerbi 2022
+
+[Na,Da] = size(a);
+[Nu,Du] = size(u);
+[Nv,Dv] = size(v);
+[Nb,Db] = size(b);
+
+if nargin < 3 || isempty(n)
+    n = max([Na,Nu,Nv,Nb]);
+else
+    if (Na ~= 1 && Na ~= n) || (Nb ~= 1 && Nb ~= n) || ...
+            (Nu ~= 1 && Nu ~= n) || (Nv ~= 1 && Nv ~= n)
+        error('mtrapezrnd:SizeError', ...
+            'A, U, V, B should be 1-by-D or N-by-D arrays.');
+    end    
+end
+if Na ~= Nb || Da ~= Db || Na ~= Nu || Da ~= Du || Na ~= Nv || Da ~= Dv
+    error('mtrapezrnd:SizeError', ...
+        'A, U, V, B should be arrays of the same size.');
+end
+
+D = Da;
+
+if size(a,1) == 1; a = repmat(a,[n,1]); end
+if size(u,1) == 1; u = repmat(u,[n,1]); end
+if size(v,1) == 1; v = repmat(v,[n,1]); end
+if size(b,1) == 1; b = repmat(b,[n,1]); end
+
+r = zeros(n,D);
+
+% Sample one dimension at a time
+for d = 1:D
+    % Compute maximum of one-dimensional pdf
+    x0 = 0.5*(u(:,d) + v(:,d));
+    y_max = mtrapezpdf(x0,a(:,d),u(:,d),v(:,d),b(:,d));
+    
+    idx = true(n,1);
+    r1 = zeros(n,1);
+    n1 = sum(idx);
+    
+    % Keep doing rejection sampling
+    while n1 > 0        
+        % Uniform sampling in the box
+        r1(idx) = bsxfun(@plus, a(idx,d), bsxfun(@times, rand(n1,1), b(idx,d) - a(idx,d)));
+        
+        % Rejection sampling
+        z1 = rand(n1,1) .* y_max(idx);
+        y1 = mtrapezpdf(r1(idx),a(idx,d),u(idx,d),v(idx,d),b(idx,d));
+        
+        idx_new = false(n,1);        
+        idx_new(idx) = z1 > y1; % Resample points outside
+        
+        idx = idx_new;
+        n1 = sum(idx);
+    end
+    
+    % Assign d-th dimension
+    r(:,d) = r1;
+end

--- a/shared/munifboxpdf.m
+++ b/shared/munifboxpdf.m
@@ -1,0 +1,49 @@
+function y = munifboxpdf(x,a,b)
+%MUNIFBOXPDF Multivariate uniform box probability density function.
+%   Y = MUNIFBOXPDF(X,A,B) returns the pdf of the multivariate uniform-box
+%   distribution with bounds A and B, evaluated at the values in X. The 
+%   multivariate uniform box pdf is the product of univariate uniform
+%   pdfs in each dimension. 
+%
+%   For each dimension i, the univariate uniform-box pdf is defined as:
+%
+%                 |   
+%                 |   ______________
+%         p(X(i)) |   |            |
+%                 |   |            |  
+%                 |___|____________|_____
+%                    A(i)          B(i)
+%                           X(i)
+%                          
+%   X can be a matrix, where each row is a separate point and each column
+%   is a different dimension. Similarly, A, B, C, and D can also be
+%   matrices of the same size as X.
+%
+%  See also MUNIFBOXRND.
+
+% Luigi Acerbi 2022
+
+[N,D] = size(x);
+
+if D > 1
+    if isscalar(a); a = a*ones(1,D); end
+    if isscalar(b); b = b*ones(1,D); end
+end
+
+if size(a,2) ~= D || size(b,2) ~= D
+    error('munifboxpdf:SizeError', ...
+        'A, B should be scalars or have the same number of columns as X.');
+end
+
+if size(a,1) == 1; a = repmat(a,[N,1]); end
+if size(b,1) == 1; b = repmat(b,[N,1]); end
+
+if any(a(:) >= b(:))
+    error('munifboxpdf:OrderError', ...
+        'For all elements of A and B, the order A < B should hold.');
+end
+
+nf = prod(b - a,2);
+y = 1 ./ nf .* ones(N,1);
+idx = any(bsxfun(@lt, x, a),2) | any(bsxfun(@gt, x, b),2);
+y(idx) = 0;

--- a/shared/munifboxpdf.m
+++ b/shared/munifboxpdf.m
@@ -16,10 +16,10 @@ function y = munifboxpdf(x,a,b)
 %                           X(i)
 %                          
 %   X can be a matrix, where each row is a separate point and each column
-%   is a different dimension. Similarly, A, B, C, and D can also be
-%   matrices of the same size as X.
+%   is a different dimension. Similarly, A and B can also be matrices of 
+%   the same size as X.
 %
-%  See also MUNIFBOXRND.
+%   See also MUNIFBOXRND.
 
 % Luigi Acerbi 2022
 

--- a/shared/munifboxrnd.m
+++ b/shared/munifboxrnd.m
@@ -1,0 +1,38 @@
+function r = munifboxrnd(a,b,n)
+%MUNIFBOXRND Random arrays from the multivariate uniform box distribution.
+%   R = MUNIFBOXRND(A,B) returns an N-by-D matrix R of random vectors
+%   chosen from the multivariate uniform box distribution with bounds A and
+%   B. A and B are N-by-D matrices, and MUNIFBOXRND generates each row of R 
+%   using the corresponding row of A and B.
+%
+%   R = MUNIFBOXRND(A,B,N) returns a N-by-D matrix R of random vectors
+%   chosen from the multivariate uniform box distribution with 1-by-D bound
+%   vectors A and B.
+%
+%   See also MUNIFBOXPDF.
+
+% Luigi Acerbi 2022
+
+[N,D] = size(a);
+[Nb,Db] = size(b);
+
+if nargin < 3 || isempty(n)
+    n = N;
+else
+    if (N ~= 1 && N ~= n) || (Nb ~= 1 && Nb ~= n)
+        error('munifboxrnd:SizeError', ...
+            'A and B should be 1-by-D or N-by-D arrays.');
+    end    
+end
+if N ~= Nb || D ~= Db 
+    error('munifboxrnd:SizeError', ...
+        'A and B should be arrays of the same size.');
+end
+
+if any(a(:) >= b(:))
+    error('munifboxpdf:OrderError', ...
+        'For all elements of A and B, the order A < B should hold.');
+end
+
+
+r = bsxfun(@plus, a, bsxfun(@times, rand(n,D), b - a));  

--- a/test/runtest_vbmc.m
+++ b/test/runtest_vbmc.m
@@ -1,4 +1,4 @@
-function failed = runtest(options)
+function failed = runtest_vbmc(options)
 %RUNTEST Test Variational Bayesian Monte Carlo (VBMC).
 %  RUNTEST executes a few runs of the VBMC inference algorithm to
 %  check that it is installed correctly, and returns the number of failed

--- a/test/test_pdfs_vbmc.m
+++ b/test/test_pdfs_vbmc.m
@@ -39,7 +39,19 @@ test_pdf1_normalization(pdf1,lb,ub,tolerr,name);
 test_pdf2_normalization(pdf2,lb,ub,tolerr,name);
 test_rnd(pdfrnd,pdf1,a,b,n,tolrmse,name);
 
-close all;
+%% Test multivariate smoothbox distribution
+sigma = [0.7,0.45];
+pdf1 = @(x) msmoothboxpdf(x,a(1),b(1),sigma(1));
+pdf2 = @(x) msmoothboxpdf(x,a,b,sigma);
+pdfrnd = @(n) msmoothboxrnd(a,b,sigma,n);
+name = 'msmoothbox';
+lb = [-5,-7];
+ub = [5,0];
+test_pdf1_normalization(pdf1,lb,ub,tolerr,name);
+test_pdf2_normalization(pdf2,lb,ub,tolerr,name);
+test_rnd(pdfrnd,pdf1,a,b,n,tolrmse,name);
+
+%close all;
 
 end
 

--- a/test/test_pdfs_vbmc.m
+++ b/test/test_pdfs_vbmc.m
@@ -1,0 +1,79 @@
+function test_pdfs_vbmc()
+%TEST_PDFS_VBMC Test pdfs introduced in the VBMC package.
+
+lb = [-1.1,-4.1];
+ub = [3.2,-2.8];
+a = [-1,-4];
+b = [3,-3];
+n = 1e6;
+
+tolerr = 1e-3;      % Error tolerance on normalization constant
+tolrmse = 0.05;     % Error tolerance on histogram vs pdf
+
+%% Test multivariate uniform box distribution
+pdf1 = @(x) munifboxpdf(x,a(1),b(1));
+pdf2 = @(x) munifboxpdf(x,a,b);
+pdfrnd = @(n) munifboxrnd(a,b,n);
+name = 'munifbox';
+test_pdf1_normalization(pdf1,lb,ub,tolerr,name);
+test_pdf2_normalization(pdf2,lb,ub,tolerr,name);
+test_rnd(pdfrnd,pdf1,a,b,n,tolrmse,name);
+
+%% Test multivariate trapezoidal distribution
+u = [-0.5,-3.8];
+v = [1.5,-3.4];
+pdf1 = @(x) mtrapezpdf(x,a(1),u(1),v(1),b(1));
+pdf2 = @(x) mtrapezpdf(x,a,u,v,b);
+pdfrnd = @(n) mtrapezrnd(a,u,v,b,n);
+name = 'mtrapez';
+test_pdf1_normalization(pdf1,lb,ub,tolerr,name);
+test_pdf2_normalization(pdf2,lb,ub,tolerr,name);
+test_rnd(pdfrnd,pdf1,a,b,n,tolrmse,name);
+
+%% Test multivariate spline trapezoidal distribution
+pdf1 = @(x) msplinetrapezpdf(x,a(1),u(1),v(1),b(1));
+pdf2 = @(x) msplinetrapezpdf(x,a,u,v,b);
+pdfrnd = @(n) msplinetrapezrnd(a,u,v,b,n);
+name = 'msplinetrapez';
+test_pdf1_normalization(pdf1,lb,ub,tolerr,name);
+test_pdf2_normalization(pdf2,lb,ub,tolerr,name);
+test_rnd(pdfrnd,pdf1,a,b,n,tolrmse,name);
+
+close all;
+
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function test_pdf1_normalization(pdf1,lb,ub,tol,name)
+%TEST_PDF1_NORMALIZATION Test normalization of univariate pdf.
+
+% Check 1D integral
+y = integral(@(x) pdf1(x), lb(1), ub(1), 'ArrayValued', true);
+fprintf('%s: 1D integral: %.6f\n', name, y);
+assert(abs(y - 1) < tol, ['Test error: univariate ' name ' does not integrate to 1.']);
+
+end
+
+function test_pdf2_normalization(pdf2,lb,ub,tol,name)
+%TEST_PDF2_NORMALIZATION Test normalization of bivariate pdf.
+
+% Check 2D integral
+y = integral2(@(x1,x2) reshape(pdf2([x1(:),x2(:)]),size(x1)), ...
+    lb(1), ub(1), lb(2), ub(2));
+fprintf('%s: 2D integral: %.6f\n', name, y);
+assert(abs(y - 1) < tol, ['Test error: bivariate ' name ' does not integrate to 1.']);
+
+end
+
+function test_rnd(pdfrnd,pdf1,a,b,n,tol,name)
+%TEST_RND Test random sample generation (histogram vs pdf).
+
+r = pdfrnd(n);
+h = histogram(r(:,1),100,'BinLimits',[a(1),b(1)],'Normalization','pdf');
+x = 0.5*(h.BinEdges(1:end-1) + h.BinEdges(2:end))';
+y = pdf1(x)';
+rmse = sqrt(sum(((y - h.Values)).^2*h.BinWidth));
+fprintf('%s: histogram rmse: %.6f\n', name, rmse);
+assert(rmse < tol, ['Test error: generated histogram does not match ' name ' pdf.']);
+
+end

--- a/vbmc.m
+++ b/vbmc.m
@@ -1,6 +1,6 @@
 function [vp,elbo,elbo_sd,exitflag,output,samples,optimState,stats,vp_train] = ...
     vbmc(fun,x0,LB,UB,PLB,PUB,options,varargin)
-%VBMC Posterior and model inference via Variational Bayesian Monte Carlo (v1.0.10).
+%VBMC Posterior and model inference via Variational Bayesian Monte Carlo (v1.0.11).
 %   VBMC computes a variational approximation of the full posterior and a 
 %   lower bound on the normalization constant (marginal likelhood or model
 %   evidence) for a provided unnormalized log posterior. As of v1.0, VBMC
@@ -140,8 +140,8 @@ function [vp,elbo,elbo_sd,exitflag,output,samples,optimState,stats,vp_train] = .
 %   Author (copyright): Luigi Acerbi, 2018-2022
 %   e-mail: luigi.acerbi@{helsinki.fi,gmail.com}
 %   URL: http://luigiacerbi.com
-%   Version: 1.0.10
-%   Release date: Jul 23, 2022
+%   Version: 1.0.11
+%   Release date: Sep 06, 2022
 %   Code repository: https://github.com/lacerbi/vbmc
 %--------------------------------------------------------------------------
 
@@ -149,7 +149,7 @@ function [vp,elbo,elbo_sd,exitflag,output,samples,optimState,stats,vp_train] = .
 %% Start timer
 
 t0 = tic;
-vbmc_version = '1.0.10';
+vbmc_version = '1.0.11';
 
 % Check that all VBMC subfolders are on the MATLAB path
 add2path();

--- a/vbmc.m
+++ b/vbmc.m
@@ -151,6 +151,9 @@ function [vp,elbo,elbo_sd,exitflag,output,samples,optimState,stats,vp_train] = .
 t0 = tic;
 vbmc_version = '1.0.10';
 
+% Check that all VBMC subfolders are on the MATLAB path
+add2path();
+
 %% Basic default options
 defopts.Display                 = 'iter         % Level of display ("iter", "notify", "final", or "off")';
 defopts.Plot                    = 'off          % Plot marginals of variational posterior at each iteration';
@@ -175,7 +178,7 @@ end
 if nargout <= 1 && (nargin == 1 || nargin == 2) && ischar(fun) && strcmpi(fun,'test')
     % Can run a test with a specific OPTIONS struct (otherwise use defaults)
     if nargin == 2; options = x0; else; options = []; end
-    vp = runtest(options);
+    vp = runtest_vbmc(options);
     return;
 end
 
@@ -192,7 +195,7 @@ defopts.IntegerVars             = '[]           % Array with indices of integer 
 defopts.NoiseSize               = '[]           % Base observation noise magnitude (standard deviation)';
 defopts.MaxRepeatedObservations = '0            % Max number of consecutive repeated measurements for noisy inputs';
 defopts.RepeatedAcqDiscount     = '1            % Multiplicative discount on acquisition fcn to repeat measurement at the same location';
-defopts.FunEvalStart            = 'max(D,10)    % Number of initial target fcn evals';
+defopts.FunEvalStart            = '10*ceil((D+1)/10) % Number of initial target fcn evals';
 defopts.SGDStepSize             = '0.005        % Base step size for stochastic gradient descent';
 defopts.SkipActiveSamplingAfterWarmup  = 'no    % Skip active sampling the first iteration after warmup';
 defopts.RankCriterion           = 'yes          % Use ranking criterion to pick best non-converged solution';
@@ -367,9 +370,6 @@ if strcmpi(fun,'all')
     vp = defopts;
     return;
 end
-
-%% Check that all VBMC subfolders are on the MATLAB path
-add2path();
 
 %% Input arguments
 
@@ -1056,7 +1056,7 @@ end
 function add2path()
 %ADD2PATH Adds VBMC subfolders to MATLAB path.
 
-subfolders = {'acq','ent','gplite','misc','shared','utils'};
+subfolders = {'acq','ent','gplite','misc','shared','test','utils'};
 % subfolders = {'acq','ent','gplite','misc','utils','warp'};
 pathCell = regexp(path, pathsep, 'split');
 baseFolder = fileparts(mfilename('fullpath'));

--- a/vbmc.m
+++ b/vbmc.m
@@ -141,7 +141,7 @@ function [vp,elbo,elbo_sd,exitflag,output,samples,optimState,stats,vp_train] = .
 %   e-mail: luigi.acerbi@{helsinki.fi,gmail.com}
 %   URL: http://luigiacerbi.com
 %   Version: 1.0.11
-%   Release date: Sep 06, 2022
+%   Release date: Oct 26, 2022
 %   Code repository: https://github.com/lacerbi/vbmc
 %--------------------------------------------------------------------------
 


### PR DESCRIPTION
Updated to v1.0.11:

- Added several new functions in `shared` folder for evaluating the pdf and sampling from prior distributions for both bounded and unbounded variables (uniform, trapezoidal, smoothed trapezoidal, smoothbox).
- New example in `vbmc_examples.m` describing usage of these priors.
- Added `test` folder for unit tests.
- Minor bug fix in the initialization of variational posteriors (in `vbinit_vbmc.m`).
- Added bibtex references to the readme.